### PR TITLE
Fixed the issue of success getting called twice and iframe cleanup.

### DIFF
--- a/lastfm.api.js
+++ b/lastfm.api.js
@@ -47,18 +47,18 @@ function LastFM(options){
 			iframe.width        = 1;
 			iframe.height       = 1;
 			iframe.style.border = 'none';
+
+			/* Append iframe. */
+			html.appendChild(iframe);
 			iframe.onload       = function(){
 				/* Remove iframe element. */
-				//html.removeChild(iframe);
+				html.removeChild(iframe);
 
 				/* Call user callback. */
 				if(typeof(callbacks.success) != 'undefined'){
 					callbacks.success();
 				}
 			};
-
-			/* Append iframe. */
-			html.appendChild(iframe);
 
 			/* Get iframe document. */
 			if(typeof(iframe.contentWindow) != 'undefined'){


### PR DESCRIPTION
Fixed two issues.
1) Success callback being called twice. It's a safari/webkit issue if onload is attached before appending the child to the DOM.
2) iframe elements used to POST the form was not being cleaned up.