### PR TITLE
Fix README md indentation

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -40,7 +40,7 @@ Scrobbling is not yet supported.
 You need to add the following scripts to your code in order to work with the
 JavaScript last.fm API:
 
-  <script type="text/javascript" src="lastfm.api.md5.js"></script>
+    <script type="text/javascript" src="lastfm.api.md5.js"></script>
     <script type="text/javascript" src="lastfm.api.js"></script>
 
 If you want to use caching, you need to add another script:


### PR DESCRIPTION
Hi,

There was a piece of code missing from the README due to a wrong indentation. This fixes it.

Before:

![](https://photos-1.dropbox.com/t/2/AADTvI3ZVDKRG22kUfmaefz2aoAuva5u3HfeUIQ4UjVdhw/12/7209271/png/32x32/1/1439823600/0/2/Screenshot%202015-08-17%2014.56.31.png/CLeCuAMgASACIAMgBCAFIAYgBygBKAIoBw/OMK6xRQlQTxb9kcou_L5bq0F6Wh_GqY1Ow1GM-trw84?size=1280x960&size_mode=2)

After:

![](https://photos-4.dropbox.com/t/2/AADu5JVL4PDbFBPSwPiozmqb4n2AqNdRcUxt4r86oAL2Bg/12/7209271/png/32x32/1/1439827200/0/2/Screenshot%202015-08-17%2014.56.42.png/CLeCuAMgASACIAMgBCAFIAYgBygBKAIoBw/DzYqQOKHLZtuDK_nhTgBLtmEkhZTQGA-jhuhoaA_34Q?size=1280x960&size_mode=2)