### PR TITLE
rename function getPersonalTracks to getPersonalTags

### DIFF
--- a/lastfm.api.js
+++ b/lastfm.api.js
@@ -747,8 +747,8 @@ function LastFM(options){
 			call('user.getPastEvents', params, callbacks);
 		},
 
-		getPersonalTracks : function(params, callbacks){
-			call('user.getPersonalTracks', params, callbacks);
+		getPersonalTags : function(params, callbacks){
+			call('user.getPersonalTags', params, callbacks);
 		},
 
 		getPlaylists : function(params, callbacks){


### PR DESCRIPTION
getPersonalTracks doesn't exist in the API, so I think that's been a typo nobody has noticed yet. :-)