### PR TITLE
Fix weeklyMethods caching

### DIFF
--- a/lastfm.api.cache.js
+++ b/lastfm.api.cache.js
@@ -66,8 +66,8 @@ function LastFMCache(){
 			}
 		}
 
-		for(var key in this.weeklyMethods){
-			if(method == this.weeklyMethods[key]){
+		for(var key in weeklyMethods){
+			if(method == weeklyMethods[key]){
 				return WEEK;
 			}
 		}


### PR DESCRIPTION
The array of methods with weekly expiration is declared as a private variable (var weeklyMethods) but referenced as a public property (this.weeklyMethods) meaning no weekly caching was done. weeklyMethods is now completely private.